### PR TITLE
Fixes for large texts 

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,8 +131,20 @@
         }
         try {
           const response = await fetch(
-            this.api_url + "?auth_key=" + this.api_key + "&preserve_formatting=1split_sentences=1&text=" + encodeURIComponent(this.value) + "&target_lang=" + current_language + "&source_lang=" + base_language
-          );
+            '../api/deepl', {
+              method: 'POST', 
+              headers: {
+                "X-CSRF": this.csrf,
+                "Content-Type" : "application/json"
+              },
+              body: JSON.stringify({
+                'preserve_formatting':'1',
+                'split_sentences':'1',
+                'text': this.value,
+                'target_lang': current_language,
+                'source_lang': base_language
+              })
+          });
           const data = await response.json();
           console.log(data);
           this.error = null;

--- a/index.js
+++ b/index.js
@@ -140,7 +140,7 @@
               body: JSON.stringify({
                 'preserve_formatting':'1',
                 'split_sentences':'1',
-                'text': this.value,
+                'text': encodeURIComponent(this.value),
                 'target_lang': current_language,
                 'source_lang': base_language
               })

--- a/index.js
+++ b/index.js
@@ -140,13 +140,12 @@
               body: JSON.stringify({
                 'preserve_formatting':'1',
                 'split_sentences':'1',
-                'text': encodeURIComponent(this.value),
+                'text': this.value,
                 'target_lang': current_language,
                 'source_lang': base_language
               })
           });
           const data = await response.json();
-          console.log(data);
           this.error = null;
           this.value = data.translations[0].text;
           this.$emit("input", data.translations[0].text);

--- a/index.php
+++ b/index.php
@@ -3,12 +3,6 @@ Kirby::plugin('mountbatt/deepl', [
     'fields' => [
         'deepl' => [
             'props' => [
-                'api_key' => function () {
-                    return option('mountbatt.deepl.config.api_key');
-                },
-                'api_url' => function () {
-                    return option('mountbatt.deepl.config.api_url');
-                },
                 'csrf' => function () {
                     return kirby()->csrf();
                 },

--- a/index.php
+++ b/index.php
@@ -26,19 +26,19 @@ Kirby::plugin('mountbatt/deepl', [
             [
                 'pattern' => 'deepl',
                 'method' => 'POST',
-                'action'  => function () {
-                    $options = array(
-                        'http' => array(
-                        'method' => 'POST',
-                        'header' => 
-                            "Authorization: DeepL-Auth-Key " . option('mountbatt.deepl.config.api_key') ."\r\n". 
-                            'Content-Type: application/x-www-form-urlencoded'."\r\n",
-                        'content' => http_build_query(json_decode(file_get_contents("php://input"), true))
-                    ));
-                    $context = stream_context_create($options);
-                    $response = file_get_contents(option('mountbatt.deepl.config.api_url'), false, $context);
-
-                    return $response;                
+                'action'  => function () {                   
+                    $url = option('mountbatt.deepl.config.api_url');
+                    $data = json_decode(file_get_contents("php://input"), true);
+                    $options = [
+                        'headers' => [
+                            'Authorization: DeepL-Auth-Key ' . option('mountbatt.deepl.config.api_key'),
+                            'Content-Type: application/x-www-form-urlencoded'
+                        ],
+                        'method'  => 'POST',
+                        'data'    => http_build_query($data)
+                    ];
+                    $response = Remote::request($url, $options);
+                    return $response->content();
                 }
             ]
         ]

--- a/index.php
+++ b/index.php
@@ -21,6 +21,28 @@ Kirby::plugin('mountbatt/deepl', [
             ]
         ]
     ],
+    'api' => [
+        'routes' => [
+            [
+                'pattern' => 'deepl',
+                'method' => 'POST',
+                'action'  => function () {
+                    $options = array(
+                        'http' => array(
+                        'method' => 'POST',
+                        'header' => 
+                            "Authorization: DeepL-Auth-Key " . option('mountbatt.deepl.config.api_key') ."\r\n". 
+                            'Content-Type: application/x-www-form-urlencoded'."\r\n",
+                        'content' => http_build_query(json_decode(file_get_contents("php://input"), true))
+                    ));
+                    $context = stream_context_create($options);
+                    $response = file_get_contents(option('mountbatt.deepl.config.api_url'), false, $context);
+
+                    return $response;                
+                }
+            ]
+        ]
+    ],
     'translations' => [
         'en' => [
             'mountbatt.deepl.import' => 'Import from',


### PR DESCRIPTION
Hi, I set an api endpoint to fix CORS issues and change the GET-Methode to POST-Methode

## Description
I create an api point to hide the api-key, so the CORS is happy and I change the GET-Methode to Post-Methode, like the examples on the DeepL page, so use it for larger texts. 

## Motivation
The motivation of the methode change is the length of the text I try to translate. It was to large for an normal GET-Request.

## Testing
I tested it with an large text (7,17 Kibibit) on the textarea-field and with a smaller text on the text-field